### PR TITLE
fix(dev profile): use cluster's default storage provider for the elastic search volume claim

### DIFF
--- a/zeebe-dev-profile.yaml
+++ b/zeebe-dev-profile.yaml
@@ -25,7 +25,6 @@ zeebe:
 # Request smaller persistent volumes.
     volumeClaimTemplate:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "standard"
       resources:
         requests:
           storage: 100M


### PR DESCRIPTION
For the dev profile I removed the explicit setting of the storage class (for elastic search) to 'standard'.
This  enables the cluster to use whatever default storage class it has.
Without this change it was failing on docker desktop.