### PR TITLE
fix(dev profile): elasticsearch yellow readiness check

### DIFF
--- a/zeebe-dev-profile.yaml
+++ b/zeebe-dev-profile.yaml
@@ -9,6 +9,8 @@ zeebe:
 # Permit co-located instances for solitary minikube virtual machines.
     antiAffinity: "soft"
     labels: { "app" : "zeebe" }
+# Allow no backup for single node setups
+    clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 
 # Shrink default JVM heap.
     esJavaOpts: "-Xmx128m -Xms128m"


### PR DESCRIPTION
This change downgrades the readiness check for elastic search when in dev profile from green to yellow.
Green requires the node to successfully back up to another node, it can't do this in the dev profile as there is only one node.